### PR TITLE
Auth middleware

### DIFF
--- a/backend/api/auth.go
+++ b/backend/api/auth.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/jak103/usu-gdsf/log"
+	"github.com/labstack/echo/v4"
+)
+
+func helloWorld(c echo.Context) error {
+	log.Info("Running hello world handler!")
+	return c.JSON(http.StatusOK, "Hellow orld!")
+}
+
+func init() {
+	registerRoute(route{
+		method: http.MethodGet,
+		path: "/test",
+		handler: helloWorld,
+		requireAuth: true,
+	})
+}

--- a/backend/api/routeRegistry.go
+++ b/backend/api/routeRegistry.go
@@ -3,9 +3,10 @@ package api
 import "github.com/labstack/echo/v4"
 
 type route struct {
-	method  string
-	path    string
-	handler echo.HandlerFunc
+	method      string
+	path        string
+	handler     echo.HandlerFunc
+	requireAuth bool
 }
 
 var routes []route = make([]route, 0)

--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -57,16 +57,18 @@ func (s *Server) setupMiddleware() {
 
 func (s *Server) setupRoutes() {
 	for _, route := range routes {
+		handler := route.handler
+
+		if route.requireAuth {
+			handler = auth.RequireAuthorization(route.handler)
+		}
+		
 		switch route.method {
 		case http.MethodGet:
-			if route.requireAuth {
-				s.echo.GET(route.path, auth.RequireAuthorization(route.handler))
-			} else {
-				s.echo.GET(route.path, route.handler)
-			}
+			s.echo.GET(route.path, handler)
 
 		case http.MethodPost:
-			s.echo.POST(route.path, route.handler)
+			s.echo.POST(route.path, handler)
 
 		default:
 			log.Error("Failed to register unknown method: %v", route.method)

--- a/backend/api/server.go
+++ b/backend/api/server.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/jak103/usu-gdsf/log"
+	"github.com/jak103/usu-gdsf/auth"
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 )
@@ -58,7 +59,11 @@ func (s *Server) setupRoutes() {
 	for _, route := range routes {
 		switch route.method {
 		case http.MethodGet:
-			s.echo.GET(route.path, route.handler)
+			if route.requireAuth {
+				s.echo.GET(route.path, auth.RequireAuthorization(route.handler))
+			} else {
+				s.echo.GET(route.path, route.handler)
+			}
 
 		case http.MethodPost:
 			s.echo.POST(route.path, route.handler)

--- a/backend/auth/authMiddleware.go
+++ b/backend/auth/authMiddleware.go
@@ -1,0 +1,31 @@
+package auth
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+func RequireAuthorization(handler echo.HandlerFunc) echo.HandlerFunc {
+	return func(ctx echo.Context) error {
+		authorizationHeader := ctx.Request().Header.Get("Authorization")
+		splitHeader := strings.Split(authorizationHeader, " ")
+		
+		if len(splitHeader) != 2 || strings.ToLower(splitHeader[0]) != "bearer" {
+			return echo.NewHTTPError(http.StatusUnauthorized, "Unauthorized: Invalid Authorization header")
+		}
+		
+		tokenClaims, err := DecodeAndVerifyToken(splitHeader[1], ACCESS_TOKEN)
+		
+		if err != nil {
+			return echo.NewHTTPError(http.StatusUnauthorized, fmt.Sprintf("Unauthorized: %s", err))
+		}
+
+		ctx.Set("tokenClaims", tokenClaims)
+
+		return handler(ctx)
+	}
+}
+

--- a/backend/auth/authToken.go
+++ b/backend/auth/authToken.go
@@ -70,12 +70,16 @@ func GenerateToken(params TokenParams) (string, error) {
 	return encodedToken, nil
 }
 
-func DecodeAndVerifyTokenForUser(token string, userId int64, tokenType TokenType) (*TokenClaims, error) {
+func DecodeAndVerifyToken(token string, tokenType TokenType) (*TokenClaims, error) {
+	if len(token) == 0 {
+		return nil, errors.New("Token cannot be empty")
+	}
+	
 	currentTimestamp := time.Now().UnixMilli()
 	decodedToken, err := base64.RawURLEncoding.DecodeString(token)
 
 	if err != nil {
-		return nil, errors.New("Invalid token encoding")
+		return nil, errors.New("Invalid token")
 	}
 	
 	indexOfDelimeter := bytes.LastIndexByte(decodedToken, byte('|'))
@@ -101,10 +105,6 @@ func DecodeAndVerifyTokenForUser(token string, userId int64, tokenType TokenType
 		return nil, errors.New("Incorrect token type")
 	}
 
-	if claims.UserId != userId {
-		return nil, errors.New("Token does not belong to user")
-	}
-	
 	providedHash, err := hex.DecodeString(string(providedHexHash))
 
 	if err != nil {


### PR DESCRIPTION
This allows for the automagical validation of authentication tokens on requests. Developers just need to specify `requireAuth: true` on their routes to enable the middleware.