### PR TITLE
Fixed mongouri reference in Connect method

### DIFF
--- a/backend/db/mongo.go
+++ b/backend/db/mongo.go
@@ -60,7 +60,7 @@ func (db *Mongo) Disconnect() error {
 
 // connect allows the user to connect to the database
 func (db *Mongo) Connect() error {
-	client, err := mongo.NewClient(options.Client().ApplyURI(config.RunEnv))
+	client, err := mongo.NewClient(options.Client().ApplyURI(config.MongoUri))
 	if err != nil {
 		log.WithError(err).Error("Failed to create mongo client")
 		return err


### PR DESCRIPTION
After 'config' module was setup, the mongo.Connect() method was setup to start a new Client using config.RunEnv instead of config.MongoUri . As a result, backend failed to start. Fixed the reference.