### PR TITLE
In Readme, clarify environment variables for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To start the project with docker-compose, simply run `docker-compose up -d`
 
 Once everything is up and running, simply try hitting the `/game` endpoint at `localhost:8080`
 
-## Server Configuration
+## Backend Server Configuration
 
 Server settings are configured using environment variables. The following environment variables are *required* to be defined for the server to function properly:
 


### PR DESCRIPTION
Clarify that environment variables mentioned in the current iteration of the readme are specifically for backend.